### PR TITLE
[RFC] Make zlib support multiple ISA extension (also add adler32 for SSE 4.2 and AVX2)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -124,11 +124,11 @@ cover: infcover
 
 OBJA += crc32-pclmul_asm.o
 crc32-pclmul_asm.o : contrib/amd64/crc32-pclmul_asm.S
-	$(CC) -msse4.2 -mpclmul $(CFLAGS) -p -c $< -o $@
+	$(CC) $(CFLAGS) -msse4.2 -mpclmul -p -c $< -o $@
 
 PIC_OBJA += crc32-pclmul_asm.lo
 crc32-pclmul_asm.lo : contrib/amd64/crc32-pclmul_asm.S
-	$(CC) -msse4.2 -mpclmul $(SFLAGS) -c $< -o $@
+	$(CC) $(SFLAGS) -msse4.2 -mpclmul -c $< -o $@
 
 libz.a: $(OBJS)
 	$(AR) $(ARFLAGS) $@ $(OBJS)

--- a/Makefile.in
+++ b/Makefile.in
@@ -122,17 +122,13 @@ cover: infcover
 	./infcover
 	gcov inf*.c
 
-ifneq ($(findstring -DHAS_PCLMUL, $(CFLAGS)),)
 OBJA += crc32-pclmul_asm.o
 crc32-pclmul_asm.o : contrib/amd64/crc32-pclmul_asm.S
-	$(CC) $(CFLAGS) -c $< -o $@
-endif
+	$(CC) -msse4.2 -mpclmul $(CFLAGS) -p -c $< -o $@
 
-ifneq ($(findstring -DHAS_PCLMUL, $(SFLAGS)),)
 PIC_OBJA += crc32-pclmul_asm.lo
 crc32-pclmul_asm.lo : contrib/amd64/crc32-pclmul_asm.S
-	$(CC) $(SFLAGS) -c $< -o $@
-endif
+	$(CC) -msse4.2 -mpclmul $(SFLAGS) -c $< -o $@
 
 libz.a: $(OBJS)
 	$(AR) $(ARFLAGS) $@ $(OBJS)

--- a/adler32.c
+++ b/adler32.c
@@ -11,8 +11,6 @@
 
 #include <immintrin.h>
 
-#include <stdio.h>
-
 #ifdef __x86_64__
 #include "cpuid.h"
 #endif
@@ -81,7 +79,6 @@ static uLong adler32_combine_ OF((uLong adler1, uLong adler2, z_off64_t len2));
 uLong ZEXPORT adler32_default(uLong adler, const Bytef *buf, uInt len)
 {
 	
-		printf("CALLING adler32_default\n");
     unsigned long sum2;
     unsigned n;
 
@@ -154,7 +151,6 @@ uLong ZEXPORT adler32_default(uLong adler, const Bytef *buf, uInt len)
  __attribute__ ((target ("sse4.2")))
 uLong ZEXPORT adler32_sse42(uLong adler, const Bytef *buf, uInt len)
 {
-		printf("CALLING adler32_sse42\n");
     unsigned long sum2;
 
     /* split Adler-32 into component sums */
@@ -260,7 +256,6 @@ uLong ZEXPORT adler32_sse42(uLong adler, const Bytef *buf, uInt len)
 __attribute__ ((target ("avx2")))
 uLong ZEXPORT adler32_avx2(uLong adler, const Bytef *buf, uInt len)
 {
-		printf("CALLING adler32_avx2\n");
     unsigned long sum2;
 
     /* split Adler-32 into component sums */
@@ -376,17 +371,14 @@ void *resolve_adler32(void)
 #endif /* defined(bit_AVX2) */
 
 	/* Pick AVX2 version */
-	if (has_avx2) {
-		printf("SELECT adler32_avx2\n");
+	if (has_avx2)
 		return adler32_avx2;
-	}
+
   /* Pick SSE4.2 version */
-  if (has_sse42) {
-		printf("SELECT adler32_sse42\n");
+  if (has_sse42)
     return adler32_sse42;
-	}
+
 	/* Fallback to default implementation */
-	printf("SELECT adler32_default\n");
   return adler32_default;
 }
 

--- a/adler32.c
+++ b/adler32.c
@@ -6,14 +6,30 @@
 /* @(#) $Id$ */
 
 #include "zutil.h"
+#include <xmmintrin.h>
+#include <tmmintrin.h>
 
-#define local static
+#include <immintrin.h>
 
-local uLong adler32_combine_ OF((uLong adler1, uLong adler2, z_off64_t len2));
+#include <stdio.h>
+
+#ifdef __x86_64__
+#include "cpuid.h"
+#endif
+
+static uLong adler32_combine_ OF((uLong adler1, uLong adler2, z_off64_t len2));
 
 #define BASE 65521      /* largest prime smaller than 65536 */
 #define NMAX 5552
 /* NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1 */
+
+/* 
+ * As we are using _signed_ integer arithmetic for the SSE/AVX2 implementations,
+ * we consider the max as 2^31-1
+ */
+#define NMAX_VEC 5552
+
+#define NMAX_VEC2 5552
 
 #define DO1(buf,i)  {adler += (buf)[i]; sum2 += adler;}
 #define DO2(buf,i)  DO1(buf,i); DO1(buf,i+1);
@@ -62,11 +78,10 @@ local uLong adler32_combine_ OF((uLong adler1, uLong adler2, z_off64_t len2));
 #endif
 
 /* ========================================================================= */
-uLong ZEXPORT adler32(adler, buf, len)
-    uLong adler;
-    const Bytef *buf;
-    uInt len;
+uLong ZEXPORT adler32_default(uLong adler, const Bytef *buf, uInt len)
 {
+	
+		printf("CALLING adler32_default\n");
     unsigned long sum2;
     unsigned n;
 
@@ -132,11 +147,251 @@ uLong ZEXPORT adler32(adler, buf, len)
     return adler | (sum2 << 16);
 }
 
+#define likely(x)       __builtin_expect(!!(x), 1)
+#define unlikely(x)     __builtin_expect(!!(x), 0)
+
 /* ========================================================================= */
-local uLong adler32_combine_(adler1, adler2, len2)
-    uLong adler1;
-    uLong adler2;
-    z_off64_t len2;
+ __attribute__ ((target ("sse4.2")))
+uLong ZEXPORT adler32_sse42(uLong adler, const Bytef *buf, uInt len)
+{
+		printf("CALLING adler32_sse42\n");
+    unsigned long sum2;
+
+    /* split Adler-32 into component sums */
+    sum2 = (adler >> 16) & 0xffff;
+    adler &= 0xffff;
+
+    /* in case user likes doing a byte at a time, keep it fast */
+    if (unlikely(len == 1)) {
+        adler += buf[0];
+        if (adler >= BASE)
+            adler -= BASE;
+        sum2 += adler;
+        if (sum2 >= BASE)
+            sum2 -= BASE;
+        return adler | (sum2 << 16);
+    }
+
+    /* initial Adler-32 value (deferred check for len == 1 speed) */
+    if (unlikely(buf == Z_NULL))
+        return 1L;
+
+    /* in case short lengths are provided, keep it somewhat fast */
+    if (unlikely(len < 16)) {
+        while (len--) {
+            adler += *buf++;
+            sum2 += adler;
+        }
+        if (adler >= BASE)
+            adler -= BASE;
+        MOD28(sum2);            /* only added so many BASE's */
+        return adler | (sum2 << 16);
+    }
+
+    uint32_t __attribute__ ((aligned(16))) s1[4], s2[4];
+    s1[0] = s1[1] = s1[2] = 0; s1[3] = adler;
+    s2[0] = s2[1] = s2[2] = 0; s2[3] = sum2;
+    char __attribute__ ((aligned(16))) dot1[16] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    __m128i dot1v = _mm_load_si128((__m128i*)dot1);
+    char __attribute__ ((aligned(16))) dot2[16] = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+    __m128i dot2v = _mm_load_si128((__m128i*)dot2);
+    short __attribute__ ((aligned(16))) dot3[8] = {1, 1, 1, 1, 1, 1, 1, 1};
+    __m128i dot3v = _mm_load_si128((__m128i*)dot3);
+    // We will need to multiply by 
+    //char __attribute__ ((aligned(16))) shift[4] = {0, 0, 0, 4}; //{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4};
+    char __attribute__ ((aligned(16))) shift[16] = {4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    __m128i shiftv = _mm_load_si128((__m128i*)shift);
+    while (len >= 16) {
+       __m128i vs1 = _mm_load_si128((__m128i*)s1);
+       __m128i vs2 = _mm_load_si128((__m128i*)s2);
+       __m128i vs1_0 = vs1;
+       int k = (len < NMAX_VEC ? (int)len : NMAX_VEC);
+       k -= k % 16;
+       len -= k;
+       while (k >= 16) {
+           /*
+              vs1 = adler + sum(c[i])
+              vs2 = sum2 + 16 vs1 + sum( (16-i+1) c[i] )
+
+              NOTE: 256-bit equivalents are:
+                _mm256_maddubs_epi16 <- operates on 32 bytes to 16 shorts
+                _mm256_madd_epi16    <- Sums 16 shorts to 8 int32_t.
+              We could rewrite the below to use 256-bit instructions instead of 128-bit.
+           */
+           __m128i vbuf = _mm_loadu_si128((__m128i*)buf);
+           buf += 16;
+           k -= 16;
+           __m128i v_short_sum1 = _mm_maddubs_epi16(vbuf, dot1v); // multiply-add, resulting in 8 shorts.
+           __m128i vsum1 = _mm_madd_epi16(v_short_sum1, dot3v);  // sum 8 shorts to 4 int32_t;
+           __m128i v_short_sum2 = _mm_maddubs_epi16(vbuf, dot2v);
+           vs1 = _mm_add_epi32(vsum1, vs1);
+           __m128i vsum2 = _mm_madd_epi16(v_short_sum2, dot3v);
+           vs1_0 = _mm_sll_epi32(vs1_0, shiftv);
+           vsum2 = _mm_add_epi32(vsum2, vs2);
+           vs2   = _mm_add_epi32(vsum2, vs1_0);
+           vs1_0 = vs1;
+       }
+       // At this point, we have partial sums stored in vs1 and vs2.  There are AVX512 instructions that
+       // would allow us to sum these quickly (VP4DPWSSD).  For now, just unpack and move on.
+       uint32_t __attribute__((aligned(16))) s1_unpack[4];
+       uint32_t __attribute__((aligned(16))) s2_unpack[4];
+       _mm_store_si128((__m128i*)s1_unpack, vs1);
+       _mm_store_si128((__m128i*)s2_unpack, vs2);
+       adler = (s1_unpack[0] % BASE) + (s1_unpack[1] % BASE) + (s1_unpack[2] % BASE) + (s1_unpack[3] % BASE);
+       MOD(adler);
+       s1[3] = adler;
+       sum2 = (s2_unpack[0] % BASE) + (s2_unpack[1] % BASE) + (s2_unpack[2] % BASE) + (s2_unpack[3] % BASE);
+       MOD(sum2);
+       s2[3] = sum2;
+    }
+
+    while (len--) {
+       adler += *buf++;
+       sum2 += adler;
+    }
+    MOD(adler);
+    MOD(sum2);
+
+    /* return recombined sums */
+    return adler | (sum2 << 16);
+}
+
+/* ========================================================================= */
+__attribute__ ((target ("avx2")))
+uLong ZEXPORT adler32_avx2(uLong adler, const Bytef *buf, uInt len)
+{
+		printf("CALLING adler32_avx2\n");
+    unsigned long sum2;
+
+    /* split Adler-32 into component sums */
+    sum2 = (adler >> 16) & 0xffff;
+    adler &= 0xffff;
+
+    /* in case user likes doing a byte at a time, keep it fast */
+    if (unlikely(len == 1)) {
+        adler += buf[0];
+        if (adler >= BASE)
+            adler -= BASE;
+        sum2 += adler;
+        if (sum2 >= BASE)
+            sum2 -= BASE;
+        return adler | (sum2 << 16);
+    }
+
+    /* initial Adler-32 value (deferred check for len == 1 speed) */
+    if (unlikely(buf == Z_NULL))
+        return 1L;
+
+    /* in case short lengths are provided, keep it somewhat fast */
+    if (unlikely(len < 32)) {
+        while (len--) {
+            adler += *buf++;
+            sum2 += adler;
+        }
+        if (adler >= BASE)
+            adler -= BASE;
+        MOD28(sum2);            /* only added so many BASE's */
+        return adler | (sum2 << 16);
+    }
+
+    uint32_t __attribute__ ((aligned(32))) s1[8], s2[8];
+    memset(s1, '\0', sizeof(uint32_t)*7); s1[7] = adler; // TODO: would a masked load be faster?
+    memset(s2, '\0', sizeof(uint32_t)*7); s2[7] = sum2;
+    char __attribute__ ((aligned(32))) dot1[32] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    __m256i dot1v = _mm256_load_si256((__m256i*)dot1);
+    char __attribute__ ((aligned(32))) dot2[32] = {32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+    __m256i dot2v = _mm256_load_si256((__m256i*)dot2);
+    short __attribute__ ((aligned(32))) dot3[16] = {1, 1, 1, 1, 1, 1, 1, 1,  1, 1, 1, 1, 1, 1, 1, 1};
+    __m256i dot3v = _mm256_load_si256((__m256i*)dot3);
+    // We will need to multiply by 
+    char __attribute__ ((aligned(16))) shift[16] = {5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    __m128i shiftv = _mm_load_si128((__m128i*)shift);
+    while (len >= 32) {
+       __m256i vs1 = _mm256_load_si256((__m256i*)s1);
+       __m256i vs2 = _mm256_load_si256((__m256i*)s2);
+       __m256i vs1_0 = vs1;
+       int k = (len < NMAX_VEC ? (int)len : NMAX_VEC);
+       k -= k % 32;
+       len -= k;
+       while (k >= 32) {
+           /*
+              vs1 = adler + sum(c[i])
+              vs2 = sum2 + 16 vs1 + sum( (16-i+1) c[i] )
+           */
+           __m256i vbuf = _mm256_loadu_si256((__m256i*)buf);
+           buf += 32;
+           k -= 32;
+           __m256i v_short_sum1 = _mm256_maddubs_epi16(vbuf, dot1v); // multiply-add, resulting in 8 shorts.
+           __m256i vsum1 = _mm256_madd_epi16(v_short_sum1, dot3v);  // sum 8 shorts to 4 int32_t;
+           __m256i v_short_sum2 = _mm256_maddubs_epi16(vbuf, dot2v);
+           vs1 = _mm256_add_epi32(vsum1, vs1);
+           __m256i vsum2 = _mm256_madd_epi16(v_short_sum2, dot3v);
+           vs1_0 = _mm256_sll_epi32(vs1_0, shiftv);
+           vsum2 = _mm256_add_epi32(vsum2, vs2);
+           vs2   = _mm256_add_epi32(vsum2, vs1_0);
+           vs1_0 = vs1;
+       }
+       // At this point, we have partial sums stored in vs1 and vs2.  There are AVX512 instructions that
+       // would allow us to sum these quickly (VP4DPWSSD).  For now, just unpack and move on.
+       uint32_t __attribute__((aligned(32))) s1_unpack[8];
+       uint32_t __attribute__((aligned(32))) s2_unpack[8];
+       _mm256_store_si256((__m256i*)s1_unpack, vs1);
+       _mm256_store_si256((__m256i*)s2_unpack, vs2);
+       adler = (s1_unpack[0] % BASE) + (s1_unpack[1] % BASE) + (s1_unpack[2] % BASE) + (s1_unpack[3] % BASE) + (s1_unpack[4] % BASE) + (s1_unpack[5] % BASE) + (s1_unpack[6] % BASE) + (s1_unpack[7] % BASE);
+       MOD(adler);
+       s1[7] = adler;
+       sum2 = (s2_unpack[0] % BASE) + (s2_unpack[1] % BASE) + (s2_unpack[2] % BASE) + (s2_unpack[3] % BASE) + (s2_unpack[4] % BASE) + (s2_unpack[5] % BASE) + (s2_unpack[6] % BASE) + (s2_unpack[7] % BASE);
+       MOD(sum2);
+       s2[7] = sum2;
+    }
+
+    while (len--) {
+       adler += *buf++;
+       sum2 += adler;
+    }
+    MOD(adler);
+    MOD(sum2);
+
+    /* return recombined sums */
+    return adler | (sum2 << 16);
+}
+
+uLong ZEXPORT adler32(uLong adler, const Bytef *buf, uInt len)  __attribute__ ((ifunc ("resolve_adler32")));
+
+void *resolve_adler32(void)
+{
+  unsigned int eax, ebx, ecx, edx;
+	signed char has_sse42 = 0;
+	signed char has_avx2 = 0;
+
+	/* Collect CPU features */
+  if (!__get_cpuid (1, &eax, &ebx, &ecx, &edx))
+    return adler32_default;
+	has_sse42 = ((ecx & bit_SSE4_2) != 0);
+#if defined(bit_AVX2)
+	if (__get_cpuid_max (0, NULL) < 7)
+		return adler32_default;
+	__cpuid_count (7, 0, eax, ebx, ecx, edx);
+	has_avx2 = ((ebx & bit_AVX2) != 0);
+#endif /* defined(bit_AVX2) */
+
+	/* Pick AVX2 version */
+	if (has_avx2) {
+		printf("SELECT adler32_avx2\n");
+		return adler32_avx2;
+	}
+  /* Pick SSE4.2 version */
+  if (has_sse42) {
+		printf("SELECT adler32_sse42\n");
+    return adler32_sse42;
+	}
+	/* Fallback to default implementation */
+	printf("SELECT adler32_default\n");
+  return adler32_default;
+}
+
+/* ========================================================================= */
+static uLong adler32_combine_(uLong adler1, uLong adler2, z_off64_t len2)
 {
     unsigned long sum1;
     unsigned long sum2;
@@ -162,18 +417,12 @@ local uLong adler32_combine_(adler1, adler2, len2)
 }
 
 /* ========================================================================= */
-uLong ZEXPORT adler32_combine(adler1, adler2, len2)
-    uLong adler1;
-    uLong adler2;
-    z_off_t len2;
+uLong adler32_combine(uLong adler1, uLong adler2, z_off_t len2)
 {
     return adler32_combine_(adler1, adler2, len2);
 }
 
-uLong ZEXPORT adler32_combine64(adler1, adler2, len2)
-    uLong adler1;
-    uLong adler2;
-    z_off64_t len2;
+uLong adler32_combine64(uLong adler1, uLong adler2, z_off64_t len2)
 {
     return adler32_combine_(adler1, adler2, len2);
 }

--- a/configure
+++ b/configure
@@ -742,45 +742,6 @@ EOF
   fi
 fi
 
-# Check for AMD64 hardware support.
-if [ x$TGT_ARCH = "xx86_64" -a $(uname -m) = "x86_64" ] ; then
- 
-  # Check for PCLMUL support
-cat > $test.c << EOF
-void foo(void) {
-#ifndef __PCLMUL__
-    #error no pclmul
-#endif
-}
-EOF
-
-  if try $CC -c $CFLAGS $test.c ; then
-    CFLAGS="-DHAS_PCLMUL $CFLAGS"
-    SFLAGS="-DHAS_PCLMUL $SFLAGS"
-    echo "Checking for PCLMUL support ... Yes" | tee -a configure.log
-  else
-    echo "Checking for PCLMUL support ... No" | tee -a configure.log
-  fi
-
-  # Check for SSE4.2 support. Not all compiler set __SSE4_2__ 
-cat > $test.c << EOF
-void foo(void) {
-#ifndef __SSE4_2__
-    #error no sse4.2
-#endif
-}
-EOF
-
-  if try $CC $CFLAGS $test.c -c $test; then
-    CFLAGS="-DHAS_SSE42 $CFLAGS"
-    SFLAGS="-DHAS_SSE42 $SFLAGS"
-    echo "Checking for SSE4.2 support ... Yes" | tee -a configure.log
-  else
-    echo "Checking for SSE4.2 support ... No" | tee -a configure.log
-  fi
-
-fi # end of "Check amd64 hardware support"
-
 # show the results in the log
 echo >> configure.log
 echo ALL = $ALL >> configure.log

--- a/crc32.c
+++ b/crc32.c
@@ -21,6 +21,8 @@
   DYNAMIC_CRC_TABLE and MAKECRCH can be #defined to write out crc32.h.
  */
 
+#include <stdio.h>
+
 #ifdef MAKECRCH
 #  include <stdio.h>
 #  ifndef DYNAMIC_CRC_TABLE
@@ -29,6 +31,10 @@
 #endif /* MAKECRCH */
 
 #include "zutil.h"      /* for STDC and FAR definitions */
+
+#ifdef __x86_64__
+#include "cpuid.h"
+#endif
 
 #define local static
 
@@ -235,12 +241,6 @@ local unsigned long crc32_generic(crc, buf, len)
     return crc ^ 0xffffffffUL;
 }
 
-#ifdef HAS_PCLMUL
-
-#define PCLMUL_MIN_LEN 64
-#define PCLMUL_ALIGN 16
-#define PCLMUL_ALIGN_MASK 15
-
 /* Function stolen from linux kernel 3.14. It computes the CRC over the given
  * buffer with initial CRC value <crc32>. The buffer is <len> byte in length,
  * and must be 16-byte aligned.
@@ -248,11 +248,19 @@ local unsigned long crc32_generic(crc, buf, len)
 extern uint crc32_pclmul_le_16(unsigned char const *buffer,
                                size_t len, uInt crc32);
 
-uLong crc32(crc, buf, len)
+uLong crc32_pclmul(uLong, const Bytef *, uInt) __attribute__ ((__target__ ("sse4.2,pclmul")));
+
+uLong crc32_pclmul(crc, buf, len)
     uLong crc;
     const Bytef *buf;
     uInt len;
 {
+#define PCLMUL_MIN_LEN 64
+#define PCLMUL_ALIGN 16
+#define PCLMUL_ALIGN_MASK 15
+
+//		printf("SELECTED crc32 optimized\n");
+
     if (len < PCLMUL_MIN_LEN + PCLMUL_ALIGN  - 1)
       return crc32_generic(crc, buf, len);
 
@@ -277,20 +285,36 @@ uLong crc32(crc, buf, len)
     }
 
     return crc;
-}
+
 #undef PCLMUL_MIN_LEN
 #undef PCLMUL_ALIGN
 #undef PCLMUL_ALIGN_MASK
+}
 
-#else
-uLong crc32(crc, buf, len)
+uLong crc32_default(crc, buf, len)
     uLong crc;
     const Bytef *buf;
     uInt len;
 {
+//		printf("SELECTED crc32 generic\n");
     return crc32_generic(crc, buf, len);
 }
-#endif
+
+/* This function needs to be resolved at load time */
+uLong crc32(unsigned long, const unsigned char FAR *, unsigned) 
+__attribute__ ((ifunc ("resolve_crc32")));
+
+void *resolve_crc32(void)
+{
+	unsigned int eax, ebx, ecx, edx;
+	if (!__get_cpuid (1, &eax, &ebx, &ecx, &edx))
+		return crc32_default;
+	/* We need SSE4.2 and PCLMUL ISA support */
+	if (!((ecx & bit_SSE4_2) && (ecx & bit_PCLMUL)))
+		return crc32_default;
+	printf("SELECT crc32_pclmul\n");
+	return crc32_pclmul;
+}
 
 #ifdef BYFOUR
 

--- a/crc32.c
+++ b/crc32.c
@@ -21,8 +21,6 @@
   DYNAMIC_CRC_TABLE and MAKECRCH can be #defined to write out crc32.h.
  */
 
-#include <stdio.h>
-
 #ifdef MAKECRCH
 #  include <stdio.h>
 #  ifndef DYNAMIC_CRC_TABLE
@@ -259,8 +257,6 @@ uLong crc32_pclmul(crc, buf, len)
 #define PCLMUL_ALIGN 16
 #define PCLMUL_ALIGN_MASK 15
 
-//		printf("SELECTED crc32 optimized\n");
-
     if (len < PCLMUL_MIN_LEN + PCLMUL_ALIGN  - 1)
       return crc32_generic(crc, buf, len);
 
@@ -296,7 +292,6 @@ uLong crc32_default(crc, buf, len)
     const Bytef *buf;
     uInt len;
 {
-//		printf("SELECTED crc32 generic\n");
     return crc32_generic(crc, buf, len);
 }
 
@@ -312,7 +307,6 @@ void *resolve_crc32(void)
 	/* We need SSE4.2 and PCLMUL ISA support */
 	if (!((ecx & bit_SSE4_2) && (ecx & bit_PCLMUL)))
 		return crc32_default;
-	printf("SELECT crc32_pclmul\n");
 	return crc32_pclmul;
 }
 

--- a/deflate.c
+++ b/deflate.c
@@ -49,8 +49,14 @@
 
 /* @(#) $Id$ */
 
+#include <stdio.h>
+
 #include "deflate.h"
 #include <immintrin.h>
+
+#ifdef __x86_64__
+#include "cpuid.h"
+#endif
 
 const char deflate_copyright[] =
    " deflate 1.2.8 Copyright 1995-2013 Jean-loup Gailly and Mark Adler ";
@@ -135,9 +141,42 @@ static const config configuration_table[10] = {
 /* rank Z_BLOCK between Z_NO_FLUSH and Z_PARTIAL_FLUSH */
 #define RANK(f) (((f) << 1) - ((f) > 4 ? 9 : 0))
 
-static uint32_t hash_func(deflate_state *s, void* str) {
+// UPDATE_HASH(s,h,c) (h = (((h)<<s->hash_shift) ^ (c)) & s->hash_mask)
+
+static uint32_t hash_func_sse42(deflate_state *s, void* str) __attribute__ ((__target__ ("sse4.2")));
+
+static uint32_t hash_func_sse42(deflate_state *s, void* str) {
     return _mm_crc32_u32(0, *(uint32_t*)str) & s->hash_mask;
 }
+
+static uint32_t hash_func_default(deflate_state *s, void* str) {
+	uint32_t a = *(uint32_t*)str;
+// Thomas Wang
+	a += ~(a<<15);
+	a ^=  (a>>10);
+	a +=  (a<<3);
+	a ^=  (a>>6);
+	a += ~(a<<11);
+	a ^=  (a>>16);
+// -
+  a &= s->hash_mask;
+	return a;
+}
+
+static uint32_t hash_func(deflate_state *s, void* str) __attribute__ ((ifunc ("resolve_hash_func")));
+
+void *resolve_hash_func(void)
+{
+  unsigned int eax, ebx, ecx, edx;
+  if (!__get_cpuid (1, &eax, &ebx, &ecx, &edx))
+    return hash_func_default;
+  /* We need SSE4.2 ISA support */
+  if (!(ecx & bit_SSE4_2))
+    return hash_func_default;
+	printf("SELECT hash_func_sse42\n");
+  return hash_func_sse42;
+}
+
 /* ===========================================================================
  * Insert string str in the dictionary and return the previous head
  * of the hash chain (the most recent string with same hash key).
@@ -1284,13 +1323,176 @@ static void check_match(s, start, match, length)
  *    performed for at least two bytes (required for the zip translate_eol
  *    option -- not supported here).
  */
-static void fill_window(s)
+static void fill_window_default(s)
+    deflate_state *s;
+{
+    register unsigned n, m;
+    register Pos *p;
+    unsigned more;    /* Amount of free space at the end of the window. */
+    uInt wsize = s->w_size;
+
+//		printf("SELECTED fill_window default\n");
+
+    Assert(s->lookahead < MIN_LOOKAHEAD, "already enough lookahead");
+
+    do {
+        more = (unsigned)(s->window_size -(ulg)s->lookahead -(ulg)s->strstart);
+
+        /* Deal with !@#$% 64K limit: */
+        if (sizeof(int) <= 2) {
+            if (more == 0 && s->strstart == 0 && s->lookahead == 0) {
+                more = wsize;
+
+            } else if (more == (unsigned)(-1)) {
+                /* Very unlikely, but possible on 16 bit machine if
+                 * strstart == 0 && lookahead == 1 (input done a byte at time)
+                 */
+                more--;
+            }
+        }
+
+        /* If the window is almost full and there is insufficient lookahead,
+         * move the upper half to the lower one to make room in the upper half.
+         */
+        if (s->strstart >= wsize+MAX_DIST(s)) {
+
+            zmemcpy(s->window, s->window+wsize, (unsigned)wsize);
+            s->match_start -= wsize;
+            s->strstart    -= wsize; /* we now have strstart >= MAX_DIST */
+            s->block_start -= (long) wsize;
+
+            /* Slide the hash table (could be avoided with 32 bit values
+               at the expense of memory usage). We slide even when level == 0
+               to keep the hash table consistent if we switch back to level > 0
+               later. (Using level 0 permanently is not an optimal usage of
+               zlib, so we don't care about this pathological case.)
+             */
+            n = s->hash_size;
+            p = &s->head[n];
+            do {
+                m = *--p;
+                *p = (Pos)(m >= wsize ? m-wsize : NIL);
+            } while (--n);
+
+            n = wsize;
+#ifndef FASTEST
+            p = &s->prev[n];
+            do {
+                m = *--p;
+                *p = (Pos)(m >= wsize ? m-wsize : NIL);
+                /* If n is not on any hash chain, prev[n] is garbage but
+                 * its value will never be used.
+                 */
+            } while (--n);
+#endif
+            more += wsize;
+        }
+        if (s->strm->avail_in == 0) break;
+
+        /* If there was no sliding:
+         *    strstart <= WSIZE+MAX_DIST-1 && lookahead <= MIN_LOOKAHEAD - 1 &&
+         *    more == window_size - lookahead - strstart
+         * => more >= window_size - (MIN_LOOKAHEAD-1 + WSIZE + MAX_DIST-1)
+         * => more >= window_size - 2*WSIZE + 2
+         * In the BIG_MEM or MMAP case (not yet supported),
+         *   window_size == input_size + MIN_LOOKAHEAD  &&
+         *   strstart + s->lookahead <= input_size => more >= MIN_LOOKAHEAD.
+         * Otherwise, window_size == 2*WSIZE so more >= 2.
+         * If there was sliding, more >= WSIZE. So in all cases, more >= 2.
+         */
+        Assert(more >= 2, "more < 2");
+
+        n = read_buf(s->strm, s->window + s->strstart + s->lookahead, more);
+        s->lookahead += n;
+
+        /* Initialize the hash value now that we have some input: */
+        if (s->lookahead + s->insert >= MIN_MATCH) {
+            uInt str = s->strstart - s->insert;
+            s->ins_h = s->window[str];
+//            UPDATE_HASH(s, s->ins_h, s->window[str + 1]);
+            s->ins_h = hash_func(s, &s->window[str + 1]);
+#if MIN_MATCH != 3
+            Call UPDATE_HASH() MIN_MATCH-3 more times
+#endif
+            while (s->insert) {
+//                UPDATE_HASH(s, s->ins_h, s->window[str + MIN_MATCH-1]);
+                s->ins_h = hash_func(s, &s->window[str + MIN_MATCH-1]);
+#ifndef FASTEST
+                s->prev[str & s->w_mask] = s->head[s->ins_h];
+#endif
+                s->head[s->ins_h] = (Pos)str;
+                str++;
+                s->insert--;
+                if (s->lookahead + s->insert < MIN_MATCH)
+                    break;
+            }
+        }
+        /* If the whole input has less than MIN_MATCH bytes, ins_h is garbage,
+         * but this is not important since only literal bytes will be emitted.
+         */
+
+    } while (s->lookahead < MIN_LOOKAHEAD && s->strm->avail_in != 0);
+
+    /* If the WIN_INIT bytes after the end of the current data have never been
+     * written, then zero those bytes in order to avoid memory check reports of
+     * the use of uninitialized (or uninitialised as Julian writes) bytes by
+     * the longest match routines.  Update the high water mark for the next
+     * time through here.  WIN_INIT is set to MAX_MATCH since the longest match
+     * routines allow scanning to strstart + MAX_MATCH, ignoring lookahead.
+     */
+    if (s->high_water < s->window_size) {
+        ulg curr = s->strstart + (ulg)(s->lookahead);
+        ulg init;
+
+        if (s->high_water < curr) {
+            /* Previous high water mark below current data -- zero WIN_INIT
+             * bytes or up to end of window, whichever is less.
+             */
+            init = s->window_size - curr;
+            if (init > WIN_INIT)
+                init = WIN_INIT;
+            zmemzero(s->window + curr, (unsigned)init);
+            s->high_water = curr + init;
+        }
+        else if (s->high_water < (ulg)curr + WIN_INIT) {
+            /* High water mark at or above current data, but below current data
+             * plus WIN_INIT -- zero out to current data plus WIN_INIT, or up
+             * to end of window, whichever is less.
+             */
+            init = (ulg)curr + WIN_INIT - s->high_water;
+            if (init > s->window_size - s->high_water)
+                init = s->window_size - s->high_water;
+            zmemzero(s->window + s->high_water, (unsigned)init);
+            s->high_water += init;
+        }
+    }
+
+    Assert((ulg)s->strstart <= s->window_size - MIN_LOOKAHEAD,
+           "not enough room for search");
+}
+
+/* ===========================================================================
+ * Fill the window when the lookahead becomes insufficient.
+ * Updates strstart and lookahead.
+ *
+ * IN assertion: lookahead < MIN_LOOKAHEAD
+ * OUT assertions: strstart <= window_size-MIN_LOOKAHEAD
+ *    At least one byte has been read, or avail_in == 0; reads are
+ *    performed for at least two bytes (required for the zip translate_eol
+ *    option -- not supported here).
+ */
+
+static void fill_window_sse42(deflate_state *) __attribute__ ((__target__ ("sse4.2")));
+
+static void fill_window_sse42(s)
     deflate_state *s;
 {
     register uint32_t  n, m;
     register Pos *p;
     uint32_t more;    /* Amount of free space at the end of the window. */
     uint32_t wsize = s->w_size;
+
+//		printf("SELECTED fill_window optimized\n");
 
     Assert(s->lookahead < MIN_LOOKAHEAD, "already enough lookahead");
 
@@ -1423,6 +1625,20 @@ static void fill_window(s)
 
     Assert((uint64_t)s->strstart <= s->window_size - MIN_LOOKAHEAD,
            "not enough room for search");
+}
+
+static void fill_window(deflate_state *) __attribute__ ((ifunc ("resolve_fill_window")));
+
+void *resolve_fill_window(void)
+{
+	unsigned int eax, ebx, ecx, edx;
+	if (!__get_cpuid (1, &eax, &ebx, &ecx, &edx))
+		return fill_window_default;
+	/* We need SSE4.2 ISA support */
+	if (!(ecx & bit_SSE4_2))
+		return fill_window_default;
+	printf("SELECT fill_window_sse42\n");
+	return fill_window_sse42;
 }
 
 /* ===========================================================================

--- a/deflate.c
+++ b/deflate.c
@@ -1358,16 +1358,6 @@ static void fill_window_default(s)
             } while (--n);
 
             n = wsize;
-#ifndef FASTEST
-            p = &s->prev[n];
-            do {
-                m = *--p;
-                *p = (Pos)(m >= wsize ? m-wsize : NIL);
-                /* If n is not on any hash chain, prev[n] is garbage but
-                 * its value will never be used.
-                 */
-            } while (--n);
-#endif
             more += wsize;
         }
         if (s->strm->avail_in == 0) break;
@@ -1392,17 +1382,9 @@ static void fill_window_default(s)
         if (s->lookahead + s->insert >= MIN_MATCH) {
             uInt str = s->strstart - s->insert;
             s->ins_h = s->window[str];
-//            UPDATE_HASH(s, s->ins_h, s->window[str + 1]);
             s->ins_h = hash_func(s, s->ins_h, &s->window[str + 1]);
-#if MIN_MATCH != 3
-            Call UPDATE_HASH() MIN_MATCH-3 more times
-#endif
             while (s->insert) {
-//                UPDATE_HASH(s, s->ins_h, s->window[str + MIN_MATCH-1]);
                 s->ins_h = hash_func(s, s->ins_h, &s->window[str + MIN_MATCH-1]);
-#ifndef FASTEST
-                s->prev[str & s->w_mask] = s->head[s->ins_h];
-#endif
                 s->head[s->ins_h] = (Pos)str;
                 str++;
                 s->insert--;

--- a/deflate.c
+++ b/deflate.c
@@ -49,8 +49,6 @@
 
 /* @(#) $Id$ */
 
-#include <stdio.h>
-
 #include "deflate.h"
 #include <immintrin.h>
 
@@ -141,8 +139,6 @@ static const config configuration_table[10] = {
 /* rank Z_BLOCK between Z_NO_FLUSH and Z_PARTIAL_FLUSH */
 #define RANK(f) (((f) << 1) - ((f) > 4 ? 9 : 0))
 
-// UPDATE_HASH(s,h,c) (h = (((h)<<s->hash_shift) ^ (c)) & s->hash_mask)
-
 static uint32_t hash_func_sse42(deflate_state *s, uint32_t h, void* str) __attribute__ ((__target__ ("sse4.2")));
 
 static uint32_t hash_func_sse42(deflate_state *s, uint32_t h, void* str) {
@@ -163,7 +159,6 @@ void *resolve_hash_func(void)
   /* We need SSE4.2 ISA support */
   if (!(ecx & bit_SSE4_2))
     return hash_func_default;
-	printf("SELECT hash_func_sse42\n");
   return hash_func_sse42;
 }
 
@@ -1321,8 +1316,6 @@ static void fill_window_default(s)
     unsigned more;    /* Amount of free space at the end of the window. */
     uInt wsize = s->w_size;
 
-//		printf("SELECTED fill_window default\n");
-
     Assert(s->lookahead < MIN_LOOKAHEAD, "already enough lookahead");
 
     do {
@@ -1482,8 +1475,6 @@ static void fill_window_sse42(s)
     uint32_t more;    /* Amount of free space at the end of the window. */
     uint32_t wsize = s->w_size;
 
-//		printf("SELECTED fill_window optimized\n");
-
     Assert(s->lookahead < MIN_LOOKAHEAD, "already enough lookahead");
 
     do {
@@ -1627,7 +1618,6 @@ void *resolve_fill_window(void)
 	/* We need SSE4.2 ISA support */
 	if (!(ecx & bit_SSE4_2))
 		return fill_window_default;
-	printf("SELECT fill_window_sse42\n");
 	return fill_window_sse42;
 }
 

--- a/deflate.c
+++ b/deflate.c
@@ -1358,6 +1358,16 @@ static void fill_window_default(s)
             } while (--n);
 
             n = wsize;
+#ifndef FASTEST
+            p = &s->prev[n];
+            do {
+                m = *--p;
+                *p = (Pos)(m >= wsize ? m-wsize : NIL);
+                /* If n is not on any hash chain, prev[n] is garbage but
+                 * its value will never be used.
+                 */
+            } while (--n);
+#endif
             more += wsize;
         }
         if (s->strm->avail_in == 0) break;
@@ -1382,9 +1392,17 @@ static void fill_window_default(s)
         if (s->lookahead + s->insert >= MIN_MATCH) {
             uInt str = s->strstart - s->insert;
             s->ins_h = s->window[str];
+//            UPDATE_HASH(s, s->ins_h, s->window[str + 1]);
             s->ins_h = hash_func(s, s->ins_h, &s->window[str + 1]);
+#if MIN_MATCH != 3
+            Call UPDATE_HASH() MIN_MATCH-3 more times
+#endif
             while (s->insert) {
+//                UPDATE_HASH(s, s->ins_h, s->window[str + MIN_MATCH-1]);
                 s->ins_h = hash_func(s, s->ins_h, &s->window[str + MIN_MATCH-1]);
+#ifndef FASTEST
+                s->prev[str & s->w_mask] = s->head[s->ins_h];
+#endif
                 s->head[s->ins_h] = (Pos)str;
                 str++;
                 s->insert--;

--- a/deflate.c
+++ b/deflate.c
@@ -1358,7 +1358,6 @@ static void fill_window_default(s)
             } while (--n);
 
             n = wsize;
-#ifndef FASTEST
             p = &s->prev[n];
             do {
                 m = *--p;
@@ -1367,7 +1366,6 @@ static void fill_window_default(s)
                  * its value will never be used.
                  */
             } while (--n);
-#endif
             more += wsize;
         }
         if (s->strm->avail_in == 0) break;
@@ -1392,17 +1390,10 @@ static void fill_window_default(s)
         if (s->lookahead + s->insert >= MIN_MATCH) {
             uInt str = s->strstart - s->insert;
             s->ins_h = s->window[str];
-//            UPDATE_HASH(s, s->ins_h, s->window[str + 1]);
             s->ins_h = hash_func(s, s->ins_h, &s->window[str + 1]);
-#if MIN_MATCH != 3
-            Call UPDATE_HASH() MIN_MATCH-3 more times
-#endif
             while (s->insert) {
-//                UPDATE_HASH(s, s->ins_h, s->window[str + MIN_MATCH-1]);
                 s->ins_h = hash_func(s, s->ins_h, &s->window[str + MIN_MATCH-1]);
-#ifndef FASTEST
                 s->prev[str & s->w_mask] = s->head[s->ins_h];
-#endif
                 s->head[s->ins_h] = (Pos)str;
                 str++;
                 s->insert--;


### PR DESCRIPTION
This is marked as RFC, this is a draft for potential implementation.

The changes allow building zlib on generic target with optimized bits for the specific ISA extensions.  The optimized functions are selected at load-time via `ifunc` mechanism.  This also adds `adler32` for generic, SSE 4.2 and AVX2 targets (done by Brian P. Bockelman).

This allows us to ship zlib binary to 100+ different CPUs from the last 10 years and pick the best implementation based on hardware capabilities. On my tests on Haswell machine I have not noticed any performance regressions + the same binary was working on Core 2 Duo system (generic target).  More precise testings could be done with QEMU/KVM. This zlib was added to our CI system for the last few weeks and we have not noticed any crashes caused by it in our software so far.

Would there be an interest to add such capabilities to Cloudfare zlib?