### PR TITLE
Changes to allow compilation using MSVC 2010

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,3 +247,11 @@ if(HAVE_OFF64_T)
     target_link_libraries(minigzip64 zlib)
     set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
 endif()
+
+#============================================================================
+# work around to CMake bug which affects 64-bit Windows
+# see http://public.kitware.com/Bug/view.php?id=11240
+#============================================================================
+if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND MSVC)
+  set_target_properties(zlibstatic PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
+endif()

--- a/deflate.h
+++ b/deflate.h
@@ -311,7 +311,23 @@ void ZLIB_INTERNAL _tr_stored_block(deflate_state *s, uint8_t *buf,
 extern const uint8_t ZLIB_INTERNAL _length_code[];
 extern const uint8_t ZLIB_INTERNAL _dist_code[];
 
+#ifdef _MSC_VER
+
+/* MSC doesn't have __builtin_expect.  Just ignore likely/unlikely and
+   hope the compiler optimizes for the best.
+*/
+#define likely(x)       (x)
+#define unlikely(x)     (x)
+
+int __inline __builtin_ctzl(unsigned long mask)
+{
+    unsigned long index ;
+
+    return _BitScanForward(&index, mask) == 0 ? 32 : ((int)index) ;
+}
+#else
 #define likely(x)       __builtin_expect((x),1)
 #define unlikely(x)     __builtin_expect((x),0)
+#endif
 
 #endif /* DEFLATE_H */

--- a/trees.c
+++ b/trees.c
@@ -1035,6 +1035,9 @@ static void compress_block(s, ltree, dtree)
     uint64_t bit_buf = s->bi_buf;
     int filled = s->bi_valid;
 
+    uint64_t val ;
+    int len ;
+
     if (s->last_lit != 0) do {
         dist = s->d_buf[lx];
         lc = s->l_buf[lx++];
@@ -1058,11 +1061,13 @@ static void compress_block(s, ltree, dtree)
 
             Tracecv(isgraph(lc), (stderr," '%c' ", lc));
         } else {
+            uint64_t val ;
+            int len ;
             /* Here, lc is the match length - MIN_MATCH */
             code = _length_code[lc];
 
-            uint64_t val = ltree[code+LITERALS+1].Code;
-            int len = ltree[code+LITERALS+1].Len;
+            val = ltree[code+LITERALS+1].Code;
+            len = ltree[code+LITERALS+1].Len;
 #ifdef DEBUG
             Tracevv((stderr," l %2d v %4llx ", len, val));
             Assert(len > 0 && len <= 64, "invalid length");
@@ -1143,8 +1148,9 @@ static void compress_block(s, ltree, dtree)
                "pendingBuf overflow");
 
     } while (lx < s->last_lit);
-    uint64_t val = ltree[END_BLOCK].Code;
-    int len = ltree[END_BLOCK].Len;
+    val = ltree[END_BLOCK].Code;
+    len = ltree[END_BLOCK].Len;
+
 #ifdef DEBUG
     Tracevv((stderr," l %2d v %4llx ", len, val));
     Assert(len > 0 && len <= 64, "invalid length");


### PR DESCRIPTION
ZLib can be compiled with Microsoft Visual Studio 2010, but there are a few minor changes in cloudflare's fork that prevent compilation.  This pull request moves around some variable declarations to top of block to allow C89 compatibility.  It also ifdef's in definitions for likely/unlikely and _builtin_ctzl if _MSC_VER is set.

Please let me know if these changes look ok, or if you think I should make any changes to them.  I'd love to have the ability to use MSVC pulled back into your branch.

Thanks,

--Barry