### PR TITLE
Mac and compatibility fixes

### DIFF
--- a/configure
+++ b/configure
@@ -161,6 +161,7 @@ case "$cc" in
 esac
 case `$cc -v 2>&1` in
   *gcc*) gcc=1 ;;
+  *clang*) gcc=1 ;;
 esac
 
 show $cc -c $test.c

--- a/contrib/amd64/crc32-pclmul_asm.S
+++ b/contrib/amd64/crc32-pclmul_asm.S
@@ -44,6 +44,8 @@
  *   - prepend '$' to some immediate operands to make assembler happy.
  */
 
+#if !defined(__APPLE__)
+
 #define ENTRY(name) \
 .globl name; \
 .hidden name; \
@@ -52,6 +54,17 @@ name:
 
 #define ENDPROC(name) \
 .size name, .-name
+
+#else // __APPLE__
+
+#define ENTRY(name) \
+.globl _ ## name; \
+.private_extern _ ## name; \
+_ ## name:
+
+#define ENDPROC(name) /**/
+
+#endif
 
 .align 16
 /*

--- a/deflate.c
+++ b/deflate.c
@@ -528,9 +528,9 @@ int ZEXPORT deflateTune(strm, good_length, max_lazy, nice_length, max_chain)
  * upper bound of about 14% expansion does not seem onerous for output buffer
  * allocation.
  */
-uint64_t ZEXPORT deflateBound(strm, sourceLen)
+uLong ZEXPORT deflateBound(strm, sourceLen)
     z_streamp strm;
-    uint64_t sourceLen;
+    uLong sourceLen;
 {
     deflate_state *s;
     uint64_t complen, wraplen;

--- a/test/example.c
+++ b/test/example.c
@@ -362,7 +362,7 @@ void test_large_inflate(compr, comprLen, uncompr, uncomprLen)
     CHECK_ERR(err, "inflateEnd");
 
     if (d_stream.total_out != 2*uncomprLen + comprLen/2) {
-        fprintf(stderr, "bad large inflate: %lld\n", d_stream.total_out);
+        fprintf(stderr, "bad large inflate: %ld\n", d_stream.total_out);
         exit(1);
     } else {
         printf("large_inflate(): OK\n");
@@ -559,7 +559,7 @@ int main(argc, argv)
         fprintf(stderr, "warning: different zlib version\n");
     }
 
-    printf("zlib version %s = 0x%04x, compile flags = 0x%llx\n",
+    printf("zlib version %s = 0x%04x, compile flags = 0x%lx\n",
             ZLIB_VERSION, ZLIB_VERNUM, zlibCompileFlags());
 
     compr    = (Byte*)calloc((uInt)comprLen, 1);

--- a/zconf.h
+++ b/zconf.h
@@ -408,11 +408,11 @@ typedef uLong FAR uLongf;
    typedef unsigned long z_crc_t;
 #endif
 
-#if 1    /* was set to #if 1 by ./configure */
+#ifdef HAVE_UNISTD_H    /* may be set to #if 1 by ./configure */
 #  define Z_HAVE_UNISTD_H
 #endif
 
-#if 1    /* was set to #if 1 by ./configure */
+#ifdef HAVE_STDARG_H    /* may be set to #if 1 by ./configure */
 #  define Z_HAVE_STDARG_H
 #endif
 

--- a/zconf.h
+++ b/zconf.h
@@ -365,10 +365,10 @@
 #endif
 
 #if !defined(__MACTYPES__)
-typedef uint8_t    Byte;  /* 8 bits */
+typedef unsigned char  Byte;  /* 8 bits */
 #endif
-typedef uint32_t   uInt;  /* 32 bits */
-typedef uint64_t   uLong; /* 64 bits */
+typedef unsigned int   uInt;  /* 16 bits or more */
+typedef unsigned long  uLong; /* 32 bits or more */
 
 #ifdef SMALL_MEDIUM
    /* Borland C/C++ and some old MSC versions ignore FAR inside typedef */

--- a/zconf.h.cmakein
+++ b/zconf.h.cmakein
@@ -367,10 +367,10 @@
 #endif
 
 #if !defined(__MACTYPES__)
-typedef uint8_t  Byte;  /* 8 bits */
+typedef unsigned char  Byte;  /* 8 bits */
 #endif
-typedef uint32_t  uInt;
-typedef uint64_t  uLong;
+typedef unsigned int   uInt;  /* 16 bits or more */
+typedef unsigned long  uLong; /* 32 bits or more */
 
 #ifdef SMALL_MEDIUM
    /* Borland C/C++ and some old MSC versions ignore FAR inside typedef */

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -365,10 +365,10 @@
 #endif
 
 #if !defined(__MACTYPES__)
-typedef uint8_t    Byte;  /* 8 bits */
+typedef unsigned char  Byte;  /* 8 bits */
 #endif
-typedef uint32_t   uInt;  /* 32 bits */
-typedef uint64_t   uLong; /* 64 bits */
+typedef unsigned int   uInt;  /* 16 bits or more */
+typedef unsigned long  uLong; /* 32 bits or more */
 
 #ifdef SMALL_MEDIUM
    /* Borland C/C++ and some old MSC versions ignore FAR inside typedef */


### PR DESCRIPTION
These are my current fixes for getting zlib/CloudFlare to build on Mac *and* work as a real drop-in replacement:

- build with clang
- fix the crc32_pclmul assembly so it builds on Mac (NB: it will crash in 32bit mode, PCLMUL support has to be disabled some way!)
- revert a change to the uInt and uLong types which broke building Qt and were probably dangerous anyway (several functions receive pointers to these types, and dependent software is not guaranteed to use the typedefs from zlib).