### PR TITLE
Fix compile of crc32-pclmul_asm on macOS High Sierra

### DIFF
--- a/contrib/amd64/crc32-pclmul_asm.S
+++ b/contrib/amd64/crc32-pclmul_asm.S
@@ -44,6 +44,13 @@
  *   - prepend '$' to some immediate operands to make assembler happy.
  */
 
+#ifdef __APPLE__
+#define ENTRY(name) \
+.private_extern _ ## name; \
+_ ## name:
+
+#define ENDPROC(name)
+#else
 #define ENTRY(name) \
 .globl name; \
 .hidden name; \
@@ -52,6 +59,7 @@ name:
 
 #define ENDPROC(name) \
 .size name, .-name
+#endif
 
 .align 16
 /*


### PR DESCRIPTION
* `.type` and `.size` are ELF/COFF specific so drop them
* `.globl` + `.hidden` equivalent for macOS is `.private_extern`
* assembly symbol names are not mangled on macOS, so we need to add `_` prefix

This is similar to #6, but only contains the fixes that are actually required to compile on macOS 10.13.

I have run `make test` and `make test64` and all tests are passing fine.