### PR TITLE
faster crc32 of last <8 bytes on aarch64

### DIFF
--- a/crc32.c
+++ b/crc32.c
@@ -31,22 +31,23 @@
 uint32_t crc32(uint32_t crc, uint8_t *buf, size_t len) {
     crc = ~crc;
 
-    while (len > 8) {
+    while (len >= 8) {
         crc = __crc32d(crc, *(uint64_t*)buf);
         len -= 8;
         buf += 8;
     }
 
     if (len & 4) {
-        crc = __crc32w(crc, *buf);
+        crc = __crc32w(crc, *(uint32_t*)buf);
         buf += 4;
     }
     if (len & 2) {
-        crc = __crc32h(crc, *buf);
+        crc = __crc32h(crc, *(uint16_t*)buf);
         buf += 2;
     }
-    if (len & 1)
+    if (len & 1) {
         crc = __crc32b(crc, *buf);
+    }
 
     return ~crc;
 }

--- a/crc32.c
+++ b/crc32.c
@@ -37,11 +37,16 @@ uint32_t crc32(uint32_t crc, uint8_t *buf, size_t len) {
         buf += 8;
     }
 
-    while (len) {
-        crc = __crc32b(crc, *buf);
-        len--;
-        buf++;
+    if (len & 4) {
+        crc = __crc32w(crc, *buf);
+        buf += 4;
     }
+    if (len & 2) {
+        crc = __crc32h(crc, *buf);
+        buf += 2;
+    }
+    if (len & 1)
+        crc = __crc32b(crc, *buf);
 
     return ~crc;
 }


### PR DESCRIPTION
instead of up to 7 individual bytes, process it as a word, a halfword, and a byte, and don't bother modifying the length counter