### PR TITLE
Handling undefined behavior in inffast_chunk

### DIFF
--- a/chunkcopy.h
+++ b/chunkcopy.h
@@ -427,6 +427,26 @@ static inline unsigned char FAR* chunkcopy_lapped_safe(
   return chunkcopy_lapped_relaxed(out, dist, len);
 }
 
+/* TODO(cavalcanti): see crbug.com/1110083. */
+static inline unsigned char FAR* chunkcopy_safe_ugly(unsigned char FAR* out,
+                                                     unsigned dist,
+                                                     unsigned len,
+                                                     unsigned char FAR* limit) {
+#if defined(__GNUC__) && !defined(__clang__)
+  /* Speed is the same as using chunkcopy_safe
+     w/ GCC on ARM (tested gcc 6.3 and 7.5) and avoids
+     undefined behavior.
+  */
+  return chunkcopy_core_safe(out, out - dist, len, limit);
+#elif defined(__clang__) && !defined(__aarch64__)
+  /* Seems to perform better on 32bit (i.e. Android). */
+  return chunkcopy_core_safe(out, out - dist, len, limit);
+#else
+  /* Seems to perform better on 64-bit. */
+  return chunkcopy_lapped_safe(out, dist, len, limit);
+#endif
+}
+
 /*
  * The chunk-copy code above deals with writing the decoded DEFLATE data to
  * the output with SIMD methods to increase decode speed. Reading the input

--- a/inffast_chunk.c
+++ b/inffast_chunk.c
@@ -296,7 +296,7 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
                            the main copy is near the end.
                           */
                         out = chunkunroll_relaxed(out, &dist, &len);
-                        out = chunkcopy_safe(out, out - dist, len, limit);
+                        out = chunkcopy_safe_ugly(out, dist, len, limit);
                     } else {
                         /* from points to window, so there is no risk of
                            overlapping pointers requiring memset-like behaviour


### PR DESCRIPTION
This ports a21a4e8 - "Handling undefined behavior in inffast_chunk" from the Chromium fork of zlib by Adenilson Cavalcanti.

Link to patch being ported: https://chromium.googlesource.com/chromium/src/third_party/zlib/+/a21a4e8f27567b7c36f8274bf16ebca78b9a68ab%5E%21/#F0
