### PR TITLE
Fix a bug that can crash deflate on some input when using Z_FIXED.

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -204,7 +204,7 @@ typedef struct internal_state {
     /* Depth of each subtree used as tie breaker for trees of equal frequency
      */
 
-    uint8_t *l_buf;          /* buffer for literals or lengths */
+    uint8_t *sym_buf;        /* buffer for distances and literals/lengths */
 
     uint32_t  lit_bufsize;
     /* Size of match buffer for literals/lengths.  There are 4 reasons for
@@ -226,13 +226,8 @@ typedef struct internal_state {
      *   - I can't count above 4
      */
 
-    uint32_t last_lit;      /* running index in l_buf */
-
-    uint16_t *d_buf;
-    /* Buffer for distances. To simplify the code, d_buf and l_buf have
-     * the same number of elements. To use different lengths, an extra flag
-     * array would be necessary.
-     */
+    uInt sym_next;      /* running index in sym_buf */
+    uInt sym_end;       /* symbol table full when sym_next reaches this */
 
     uint64_t opt_len;        /* bit length of current block with optimal trees */
     uint64_t static_len;     /* bit length of current block with static trees */
@@ -311,6 +306,26 @@ void ZLIB_INTERNAL _tr_stored_block(deflate_state *s, uint8_t *buf,
 extern const uint8_t ZLIB_INTERNAL _length_code[];
 extern const uint8_t ZLIB_INTERNAL _dist_code[];
 
+# define _tr_tally_lit(s, c, flush) \
+  { uch cc = (c); \
+    s->sym_buf[s->sym_next++] = 0; \
+    s->sym_buf[s->sym_next++] = 0; \
+    s->sym_buf[s->sym_next++] = cc; \
+    s->dyn_ltree[cc].Freq++; \
+    flush = (s->sym_next == s->sym_end); \
+   }
+# define _tr_tally_dist(s, distance, length, flush) \
+  { uch len = (uch)(length); \
+    ush dist = (ush)(distance); \
+    s->sym_buf[s->sym_next++] = dist; \
+    s->sym_buf[s->sym_next++] = dist >> 8; \
+    s->sym_buf[s->sym_next++] = len; \
+    dist--; \
+    s->dyn_ltree[_length_code[len]+LITERALS+1].Freq++; \
+    s->dyn_dtree[d_code(dist)].Freq++; \
+    flush = (s->sym_next == s->sym_end); \
+  }
+
 #ifdef _MSC_VER
 
 /* MSC doesn't have __builtin_expect.  Just ignore likely/unlikely and
@@ -322,9 +337,6 @@ extern const uint8_t ZLIB_INTERNAL _dist_code[];
 int __inline __builtin_ctzl(unsigned long mask)
 {
     unsigned long index ;
-
-    return _BitScanForward(&index, mask) == 0 ? 32 : ((int)index) ;
-}
 #else
 #define likely(x)       __builtin_expect((x),1)
 #define unlikely(x)     __builtin_expect((x),0)

--- a/trees.c
+++ b/trees.c
@@ -385,7 +385,7 @@ static void init_block(s)
 
     s->dyn_ltree[END_BLOCK].Freq = 1;
     s->opt_len = s->static_len = 0L;
-    s->last_lit = s->matches = 0;
+    s->sym_next = s->matches = 0;
 }
 
 #define SMALLEST 1
@@ -910,7 +910,7 @@ void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
 
         Tracev((stderr, "\nopt %llu(%llu) stat %llu(%llu) stored %llu lit %u ",
                 opt_lenb, s->opt_len, static_lenb, s->static_len, stored_len,
-                s->last_lit));
+                s->sym_next / 3));
 
         if (static_lenb <= opt_lenb) opt_lenb = static_lenb;
 
@@ -976,8 +976,9 @@ int ZLIB_INTERNAL _tr_tally (s, dist, lc)
     unsigned dist;  /* distance of matched string */
     unsigned lc;    /* match length-MIN_MATCH or unmatched char (if dist==0) */
 {
-    s->d_buf[s->last_lit] = (uint16_t)dist;
-    s->l_buf[s->last_lit++] = (uint8_t)lc;
+    s->sym_buf[s->sym_next++] = (uint16_t)dist;
+    s->sym_buf[s->sym_next++] = (uint16_t)dist >> 8;
+    s->sym_buf[s->sym_next++] = (uint8_t)lc;
     if (dist == 0) {
         /* lc is the unmatched char */
         s->dyn_ltree[lc].Freq++;
@@ -992,30 +993,7 @@ int ZLIB_INTERNAL _tr_tally (s, dist, lc)
         s->dyn_ltree[_length_code[lc]+LITERALS+1].Freq++;
         s->dyn_dtree[d_code(dist)].Freq++;
     }
-
-#ifdef TRUNCATE_BLOCK
-    /* Try to guess if it is profitable to stop the current block here */
-    if ((s->last_lit & 0x1fff) == 0 && s->level > 2) {
-        /* Compute an upper bound for the compressed length */
-        uint64_t out_length = (ulg)s->last_lit*8L;
-        uint64_t in_length = (ulg)((long)s->strstart - s->block_start);
-        int dcode;
-        for (dcode = 0; dcode < D_CODES; dcode++) {
-            out_length += (ulg)s->dyn_dtree[dcode].Freq *
-                (5L+extra_dbits[dcode]);
-        }
-        out_length >>= 3;
-        Tracev((stderr,"\nlast_lit %u, in %ld, out ~%ld(%ld%%) ",
-               s->last_lit, in_length, out_length,
-               100L - out_length*100L/in_length));
-        if (s->matches < s->last_lit/2 && out_length < in_length/2) return 1;
-    }
-#endif
-    return (s->last_lit == s->lit_bufsize-1);
-    /* We avoid equality with lit_bufsize because of wraparound at 64K
-     * on 16 bit machines and because stored blocks are restricted to
-     * 64K-1 bytes.
-     */
+    return (s->sym_next == s->sym_end);
 }
 
 /* ===========================================================================
@@ -1028,19 +1006,20 @@ static void compress_block(s, ltree, dtree)
 {
     unsigned dist;      /* distance of matched string */
     int lc;             /* match length or unmatched char (if dist == 0) */
-    unsigned lx = 0;    /* running index in l_buf */
+    unsigned sx = 0;    /* running index in sym_buf */
     unsigned code;      /* the code to send */
     int extra;          /* number of extra bits to send */
 
     uint64_t bit_buf = s->bi_buf;
     int filled = s->bi_valid;
 
-    uint64_t val ;
-    int len ;
+    uint64_t val;
+    int len;
 
-    if (s->last_lit != 0) do {
-        dist = s->d_buf[lx];
-        lc = s->l_buf[lx++];
+    if (s->sym_next != 0) do {
+        dist = s->sym_buf[sx++] & 0xff;
+        dist += (unsigned)(s->sym_buf[sx++] & 0xff) << 8;
+        lc = s->sym_buf[sx++];
         if (dist == 0) {
             uint64_t val = ltree[lc].Code;
             int len = ltree[lc].Len;
@@ -1143,11 +1122,11 @@ static void compress_block(s, ltree, dtree)
             }
         } /* literal or match pair ? */
 
-        /* Check that the overlay between pending_buf and d_buf+l_buf is ok: */
-        Assert((uInt)(s->pending) < s->lit_bufsize + 2*lx,
-               "pendingBuf overflow");
+        /* Check that the overlay between pending_buf and sym_buf is ok: */
+        Assert(s->pending < s->lit_bufsize + sx, "pendingBuf overflow");
 
-    } while (lx < s->last_lit);
+    } while (sx < s->sym_next);
+
     val = ltree[END_BLOCK].Code;
     len = ltree[END_BLOCK].Len;
 


### PR DESCRIPTION
Port of the patch for CVE-2018-25032 from
https://github.com/madler/zlib/commit/5c44459c3b28a9bd3283aaceab7c615f8020c531

This bug was reported by Danilo Ramos of Eideticom, Inc. It has
lain in wait 13 years before being found! The bug was introduced
in zlib 1.2.2.2, with the addition of the Z_FIXED option. That
option forces the use of fixed Huffman codes. For rare inputs with
a large number of distant matches, the pending buffer into which
the compressed data is written can overwrite the distance symbol
table which it overlays. That results in corrupted output due to
invalid distances, and can result in out-of-bound accesses,
crashing the application.

The fix here combines the distance buffer and literal/length
buffers into a single symbol buffer. Now three bytes of pending
buffer space are opened up for each literal or length/distance
pair consumed, instead of the previous two bytes. This assures
that the pending buffer cannot overwrite the symbol table, since
the maximum fixed code compressed length/distance is 31 bits, and
since there are four bytes of pending space for every three bytes
of symbol space.