### PR TITLE
Avoid writing padding bytes if no content is inflated

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -1290,12 +1290,24 @@ int flush;
        Note: a memory error from inflate() is non-recoverable.
      */
   inf_leave:
-#if defined(INFLATE_CHUNK_SIMD_NEON) || defined(INFLATE_CHUNK_SIMD_SSE2)
-    /* We write a defined value in the unused space to help mark
-     * where the stream has ended. We don't use zeros as that can
-     * mislead clients relying on undefined behavior (i.e. assuming
-     * that the data is over when the buffer has a zero/null value).
-     */
+#if defined(DEBUG) && (defined(INFLATE_CHUNK_SIMD_NEON) || defined(INFLATE_CHUNK_SIMD_SSE2))
+    /* XXX(cavalcantii): I put this in place back in 2017 to help debug faulty
+    * client code relying on undefined behavior when chunk_copy first landed.
+    *
+    * It is save to say after all these years that Chromium code is well
+    * behaved and works fine with the optimization, therefore we can enable
+    * this only for DEBUG builds.
+    *
+    * We write a defined value in the unused space to help mark
+    * where the stream has ended. We don't use zeros as that can
+    * mislead clients relying on undefined behavior (i.e. assuming
+    * that the data is over when the buffer has a zero/null value).
+    *
+    * The basic idea is that if client code is not relying on the zlib context
+    * to inform the amount of decompressed data, but instead reads the output
+    * buffer until a zero/null is found, it will fail faster and harder
+    * when the remaining of the buffer is marked with a symbol (e.g. 0x55).
+    */
     if (left >= CHUNKCOPY_CHUNK_SIZE)
        memset(put, 0x55, CHUNKCOPY_CHUNK_SIZE);
     else


### PR DESCRIPTION
Port the change for Chromium issue 1302606 which avoids writing padding bytes for debug purposes except for debug builds. In particular, this ensures that the JDK `InflaterInputStream::read(byte[] b, int off, int len)` contract can be satisfied by this implementation. See:

- https://bugs.chromium.org/p/chromium/issues/detail?id=1302606
- https://chromium.googlesource.com/chromium/src/+/36be3c7a465f00f4edefccc10bba00bbebe1843d%5E%21/

This is complementary to the work Volker Simonis is doing upstream on making `InflaterInputStream` more tolerant of this kind of behavior, providing compatibility for earlier JDK releases.

- https://bugs.openjdk.org/browse/JDK-8281962
- https://bugs.openjdk.org/browse/JDK-8283758
