### PR TITLE
Export 'inflateValidate' as ZLIB_1.2.9 symbol

### DIFF
--- a/zlib.map
+++ b/zlib.map
@@ -81,3 +81,7 @@ ZLIB_1.2.7.1 {
     inflateGetDictionary;
     gzvprintf;
 } ZLIB_1.2.5.2;
+
+ZLIB_1.2.9 {
+    inflateValidate;
+} ZLIB_1.2.7.1;


### PR DESCRIPTION
The current version of zlib-cloudflare can not be used with libpng 1.6.29 and later (or applications using libpng 1.6.29+) because libpng requires ZLIB_1.2.9 symbols but zlib-cloudflare is based on zlib 1.2.8. E.g. if running Java with zlib-cloudflare in the LD_LIBRARY_PATH the following exception can occur if the Java applications starts to use fonts; 
```
$ LD_LIBRARY_PATH=/tmp/zlib-cloudflare java HelloSwing
Exception in thread "main" java.lang.UnsatisfiedLinkError: /Java/jdk-16/lib/libfontmanager.so: \
  /tmp/zlib-cloudflare/libz.so.1: version `ZLIB_1.2.9' not found (required by /usr/lib/x86_64-linux-gnu/libpng16.so.16)
	at java.base/jdk.internal.loader.NativeLibraries.load(Native Method)
	at java.base/jdk.internal.loader.NativeLibraries$NativeLibraryImpl.open(NativeLibraries.java:383)
	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:227)
	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:169)
	at java.base/jdk.internal.loader.NativeLibraries.findFromPaths(NativeLibraries.java:310)
	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:280)
	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2392)
	at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:808)
	at java.base/java.lang.System.loadLibrary(System.java:1893)
	at java.desktop/sun.font.FontManagerNativeLibrary$1.run(FontManagerNativeLibrary.java:59)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:312)
	at java.desktop/sun.font.FontManagerNativeLibrary.<clinit>(FontManagerNativeLibrary.java:32)
	at java.desktop/sun.java2d.xr.XRSurfaceData.initXRSurfaceData(XRSurfaceData.java:104)
	at java.desktop/sun.awt.X11GraphicsEnvironment$1.run(X11GraphicsEnvironment.java:121)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:312)
	at java.desktop/sun.awt.X11GraphicsEnvironment.<clinit>(X11GraphicsEnvironment.java:58)
	at java.desktop/sun.awt.PlatformGraphicsInfo.createGE(PlatformGraphicsInfo.java:36)
	at java.desktop/java.awt.GraphicsEnvironment$LocalGE.createGE(GraphicsEnvironment.java:93)
	at java.desktop/java.awt.GraphicsEnvironment$LocalGE.<clinit>(GraphicsEnvironment.java:84)
	at java.desktop/java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment(GraphicsEnvironment.java:106)
	at java.desktop/java.awt.Window.initGC(Window.java:488)
	at java.desktop/java.awt.Window.init(Window.java:508)
	at java.desktop/java.awt.Window.<init>(Window.java:550)
	at java.desktop/java.awt.Frame.<init>(Frame.java:426)
	at java.desktop/java.awt.Frame.<init>(Frame.java:391)
	at java.desktop/javax.swing.JFrame.<init>(JFrame.java:180)
	at HelloSwing.<init>(HelloSwing.java:9)
	at HelloSwing.main(HelloSwing.java:6)
```
This is because Java uses fontconfig which itself is dynamically linked against libpng. On Ubuntu 18.04, the dependencies look as follows:

```
$ ldd -v /usr/lib/x86_64-linux-gnu/libfontconfig.so.1
	linux-vdso.so.1 (0x00007ffff7ffa000)
	libfreetype.so.6 => /usr/lib/x86_64-linux-gnu/libfreetype.so.6 (0x00007ffff78da000)
	libexpat.so.1 => /lib/x86_64-linux-gnu/libexpat.so.1 (0x00007ffff76a8000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007ffff7489000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007ffff7098000)
	libpng16.so.16 => /usr/lib/x86_64-linux-gnu/libpng16.so.16 (0x00007ffff6e66000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007ffff6c49000)
	/lib64/ld-linux-x86-64.so.2 (0x00007ffff7dd3000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007ffff68ab000)
...
	/usr/lib/x86_64-linux-gnu/libpng16.so.16:
		libm.so.6 (GLIBC_2.2.5) => /lib/x86_64-linux-gnu/libm.so.6
		libz.so.1 (ZLIB_1.2.9) => /lib/x86_64-linux-gnu/libz.so.1
		libz.so.1 (ZLIB_1.2.3.4) => /lib/x86_64-linux-gnu/libz.so.1
```

However, when looking into libpng, we can see that up to now (i.e. libpng 1.6.38) the only required ZLIB_1.2.9 symbol is the [`inflateValidate()`](https://sourceforge.net/p/libpng/code/ci/master/tree/pngrutil.c#l427) function and fortunately, this new function was already added to zlib-cloudflare as part of the [ARM inflate performance improvement patches](https://github.com/cloudflare/zlib/pull/22) (i.e. #22).

So the only thing that remains to be done in order to make libpng 1.6.29+ work together with zlib-cloudflare is to correctly export `inflateValidate()` as ZLIB_1.2.9 symbol, and that's exactly what this PR proposes.
