### PR TITLE
Fix building on MSVC

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -337,6 +337,9 @@ extern const uint8_t ZLIB_INTERNAL _dist_code[];
 int __inline __builtin_ctzl(unsigned long mask)
 {
     unsigned long index ;
+
+    return _BitScanForward(&index, mask) == 0 ? 32 : ((int)index) ;
+}
 #else
 #define likely(x)       __builtin_expect((x),1)
 #define unlikely(x)     __builtin_expect((x),0)


### PR DESCRIPTION
Revert change to __builtin_ctzl function made in https://github.com/cloudflare/zlib/commit/c9479d13ee1327b0c0ba6a2bd173619f08da5c91