### PR TITLE
Port inflate dynamic table size optimization

### DIFF
--- a/infback.c
+++ b/infback.c
@@ -454,11 +454,11 @@ void FAR *out_desc;
             }
 
             /* build code tables -- note: do not change the lenbits or distbits
-               values here (9 and 6) without reading the comments in inftrees.h
+               values here (10 and 9) without reading the comments in inftrees.h
                concerning the ENOUGH constants, which depend on those values */
             state->next = state->codes;
             state->lencode = (code const FAR *)(state->next);
-            state->lenbits = 9;
+            state->lenbits = 10;
             ret = inflate_table(LENS, state->lens, state->nlen, &(state->next),
                                 &(state->lenbits), state->work);
             if (ret) {
@@ -467,7 +467,7 @@ void FAR *out_desc;
                 break;
             }
             state->distcode = (code const FAR *)(state->next);
-            state->distbits = 6;
+            state->distbits = 9;
             ret = inflate_table(DISTS, state->lens + state->nlen, state->ndist,
                             &(state->next), &(state->distbits), state->work);
             if (ret) {

--- a/inflate.c
+++ b/inflate.c
@@ -1039,11 +1039,11 @@ int flush;
             }
 
             /* build code tables -- note: do not change the lenbits or distbits
-               values here (9 and 6) without reading the comments in inftrees.h
+               values here (10 and 9) without reading the comments in inftrees.h
                concerning the ENOUGH constants, which depend on those values */
             state->next = state->codes;
             state->lencode = (const code FAR *)(state->next);
-            state->lenbits = 9;
+            state->lenbits = 10;
             ret = inflate_table(LENS, state->lens, state->nlen, &(state->next),
                                 &(state->lenbits), state->work);
             if (ret) {
@@ -1052,7 +1052,7 @@ int flush;
                 break;
             }
             state->distcode = (const code FAR *)(state->next);
-            state->distbits = 6;
+            state->distbits = 9;
             ret = inflate_table(DISTS, state->lens + state->nlen, state->ndist,
                             &(state->next), &(state->distbits), state->work);
             if (ret) {

--- a/inftrees.h
+++ b/inftrees.h
@@ -36,17 +36,17 @@ typedef struct {
  */
 
 /* Maximum size of the dynamic table.  The maximum number of code structures is
-   1444, which is the sum of 852 for literal/length codes and 592 for distance
+   1924, which is the sum of 1332 for literal/length codes and 592 for distance
    codes.  These values were found by exhaustive searches using the program
    examples/enough.c found in the zlib distribtution.  The arguments to that
    program are the number of symbols, the initial root table size, and the
-   maximum bit length of a code.  "enough 286 9 15" for literal/length codes
-   returns returns 852, and "enough 30 6 15" for distance codes returns 592.
-   The initial root table size (9 or 6) is found in the fifth argument of the
+   maximum bit length of a code.  "enough 286 10 15" for literal/length codes
+   returns returns 1332, and "enough 30 9 15" for distance codes returns 592.
+   The initial root table size (10 or 9) is found in the fifth argument of the
    inflate_table() calls in inflate.c and infback.c.  If the root table size is
    changed, then these maximum sizes would be need to be recalculated and
    updated. */
-#define ENOUGH_LENS 852
+#define ENOUGH_LENS 1332
 #define ENOUGH_DISTS 592
 #define ENOUGH (ENOUGH_LENS+ENOUGH_DISTS)
 


### PR DESCRIPTION
Increase the size of the dynamic tables used for huffman decoding, which requires slightly more memory but leads to performance improvements across platforms.
Based on Dougall Johnson's inflate improvements via Adenilson Cavalcanti's patch for the Chromium zlib fork.
See https://chromium-review.googlesource.com/c/chromium/src/+/3888219 for details.