### PR TITLE
deflate should use __builtin_ctzll (64bit) instead of __builtin_ctzl (32bit)

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1209,7 +1209,7 @@ static uint32_t longest_match(deflate_state *s, IPos cur_match /* current match 
             uint64_t mv = *(uint64_t*)(void*)match;
             uint64_t xor = sv ^ mv;
             if (xor) {
-                int match_byte = __builtin_ctzl(xor) / 8;
+                int match_byte = __builtin_ctzll(xor) / 8;
                 scan += match_byte;
                 match += match_byte;
                 break;

--- a/deflate.h
+++ b/deflate.h
@@ -334,11 +334,11 @@ extern const uint8_t ZLIB_INTERNAL _dist_code[];
 #define likely(x)       (x)
 #define unlikely(x)     (x)
 
-int __inline __builtin_ctzl(unsigned long mask)
+uint64_t __inline __builtin_ctzll(uint64_t mask)
 {
     unsigned long index ;
 
-    return _BitScanForward(&index, mask) == 0 ? 32 : ((int)index) ;
+    return _BitScanForward64(&index, mask) == 0 ? 64 : ((int)index) ;
 }
 #else
 #define likely(x)       __builtin_expect((x),1)

--- a/deflate.h
+++ b/deflate.h
@@ -334,7 +334,7 @@ extern const uint8_t ZLIB_INTERNAL _dist_code[];
 #define likely(x)       (x)
 #define unlikely(x)     (x)
 
-uint64_t __inline __builtin_ctzll(uint64_t mask)
+int __inline __builtin_ctzll(uint64_t mask)
 {
     unsigned long index ;
 


### PR DESCRIPTION
I think the use of the 32bit operation is probably a mistake. It seems to leave an appreciable amount of compression on the table, perhaps by finding shorter matches (4 bytes) in cases where there may have been 5-8. I did not assess the performance implications. I did check the upstream code and the intention seems to have been to SWAR a fundamentally 8-byte serial process, but this intention was not achieved with the 32bit operation.

If my analysis is wrong for some arcane reason, then I think it warrants explaining in a comment at the point of the call why the strange choice was made.